### PR TITLE
Add sign-in functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:stable-alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Simple Posts App
 
-This React + TypeScript application displays posts fetched via RTK Query. The home page shows eight posts in a grid with a Sign In button to navigate to the sign-in page.
+This React + TypeScript application displays posts fetched via RTK Query. The home page shows eight posts in a grid with the ability to sign in using a username from JSONPlaceholder.
+
+## Authentication
+
+Click **Sign In** on the home page to open the sign‑in form. Enter a username (for example `Bret`) and submit. If the user exists, the data will be stored in Redux and the button on the home page will change to **Log Out**.
+
+## Docker
+
+To build and run the application using Docker:
+
+```bash
+docker build -t posts-app .
+docker run -p 3000:80 posts-app
+```
 
 # Getting Started with Create React App
 

--- a/src/HomePage.module.css
+++ b/src/HomePage.module.css
@@ -7,7 +7,7 @@
   color: white;
 }
 
-.signin-button {
+.signinButton {
   color: white;
   text-decoration: none;
   padding: 0.5rem 1rem;

--- a/src/HomePage.tsx
+++ b/src/HomePage.tsx
@@ -1,20 +1,36 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useGetPostsQuery } from './features/posts/postsApi';
-import './HomePage.css';
+import { useAppSelector, useAppDispatch } from './app/hooks';
+import { clearUser } from './features/auth/authSlice';
+import styles from './HomePage.module.css';
 
 const HomePage: React.FC = () => {
   const { data: posts = [] } = useGetPostsQuery();
+  const user = useAppSelector((state) => state.auth.user);
+  const dispatch = useAppDispatch();
+
+  const handleLogout = () => {
+    dispatch(clearUser());
+  };
 
   return (
     <div>
-      <header className="header">
-        <h1 className="title">Posts</h1>
-        <Link to="/signin" className="signin-button">Sign In</Link>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Posts</h1>
+        {user ? (
+          <button onClick={handleLogout} className={styles.signinButton}>
+            Log Out
+          </button>
+        ) : (
+          <Link to="/signin" className={styles.signinButton}>
+            Sign In
+          </Link>
+        )}
       </header>
-      <div className="grid">
+      <div className={styles.grid}>
         {posts.slice(0, 8).map(post => (
-          <div key={post.id} className="tile">
+          <div key={post.id} className={styles.tile}>
             <h3>{post.title}</h3>
             <p>{post.body}</p>
           </div>

--- a/src/SignInPage.module.css
+++ b/src/SignInPage.module.css
@@ -1,0 +1,41 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  background-color: #282c34;
+  color: white;
+}
+
+.title {
+  margin: 0;
+}
+
+.signinButton {
+  color: white;
+  text-decoration: none;
+  padding: 0.5rem 1rem;
+  border: 1px solid white;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+}
+
+.card {
+  max-width: 300px;
+  margin: 2rem auto;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.input {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.submitButton {
+  width: 100%;
+  padding: 0.5rem;
+}

--- a/src/SignInPage.tsx
+++ b/src/SignInPage.tsx
@@ -1,14 +1,54 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAppDispatch } from './app/hooks';
+import { setUser } from './features/auth/authSlice';
+import styles from './SignInPage.module.css';
 
 const SignInPage: React.FC = () => {
+  const [username, setUsername] = useState('');
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const response = await fetch(
+        `https://jsonplaceholder.typicode.com/users?username=${username}`
+      );
+      if (!response.ok) throw new Error('Network error');
+      const data = await response.json();
+      if (data.length > 0) {
+        dispatch(setUser(data[0]));
+        navigate('/');
+      } else {
+        alert('User not found');
+      }
+    } catch (err) {
+      console.error(err);
+      alert('Failed to sign in');
+    }
+  };
+
   return (
     <div>
-      <header className="header">
-        <h1 className="title">Sign In</h1>
-        <Link to="/" className="signin-button">Home</Link>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Sign In</h1>
+        <Link to="/" className={styles.signinButton}>Home</Link>
       </header>
-      <p style={{ padding: '1rem' }}>This is the sign-in page.</p>
+      <div className={styles.card}>
+        <form onSubmit={handleSubmit}>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="Username"
+            className={styles.input}
+          />
+          <button type="submit" className={styles.submitButton}>
+            Send
+          </button>
+        </form>
+      </div>
     </div>
   );
 };

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { postsApi } from '../features/posts/postsApi';
+import authReducer from '../features/auth/authSlice';
 
 export const store = configureStore({
   reducer: {
     [postsApi.reducerPath]: postsApi.reducer,
+    auth: authReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(postsApi.middleware),

--- a/src/features/auth/authSlice.ts
+++ b/src/features/auth/authSlice.ts
@@ -1,0 +1,53 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface Address {
+  street: string;
+  suite: string;
+  city: string;
+  zipcode: string;
+  geo: {
+    lat: string;
+    lng: string;
+  };
+}
+
+export interface Company {
+  name: string;
+  catchPhrase: string;
+  bs: string;
+}
+
+export interface User {
+  id: number;
+  name: string;
+  username: string;
+  email: string;
+  address: Address;
+  phone: string;
+  website: string;
+  company: Company;
+}
+
+interface AuthState {
+  user: User | null;
+}
+
+const initialState: AuthState = {
+  user: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setUser(state, action: PayloadAction<User>) {
+      state.user = action.payload;
+    },
+    clearUser(state) {
+      state.user = null;
+    },
+  },
+});
+
+export const { setUser, clearUser } = authSlice.actions;
+export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- support user authentication with Redux slice
- convert pages to CSS modules
- implement sign-in form and logout
- show login state in home page
- provide Dockerfile
- update README with usage instructions

## Testing
- `npm install`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6862e1b9564083329abed35c83223965